### PR TITLE
Add POLLING_TIMEOUT configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ steps:
 ## Vulnerability Blocking
 The plugin supports automatic build blocking based on security findings. When `BLOCK_ON_SEVERITY` is specified, the plugin will:
 
-1. Wait for the scan to complete (up to 5 minutes)
+1. Wait for the scan to complete (default: 5 minutes, configurable via `POLLING_TIMEOUT`)
 2. Check for security findings at or above the specified severity level
 3. Block the build if any vulnerabilities are found at the minimum severity threshold
 
@@ -138,6 +138,15 @@ Supported values:
 - `HIGH`: Block on high severity vulnerabilities only
 - `MEDIUM`: Block on medium and high severity vulnerabilities
 - `LOW`: Block on all severity vulnerabilities (low, medium, high)
+
+### `POLLING_TIMEOUT` (Optional, number)
+Timeout duration in seconds for polling scan results. Default is 300 seconds (5 minutes).
+This parameter only applies when `POLL_SCAN_RESULTS` is `true` or when `BLOCK_ON_SEVERITY` is set.
+
+Example:
+```yml
+POLLING_TIMEOUT: 600  # Wait up to 10 minutes for scan results
+```
 
 It should look like this in your Buildkite agent secret settings
 ![buildkite-data-theorem-mobile-secure-plugin-secrets.png](images%2Fbuildkite-data-theorem-mobile-secure-plugin-secrets.png)

--- a/hooks/command
+++ b/hooks/command
@@ -127,7 +127,7 @@ fi
 
 maxRetries=3
 upload_success=false
-timeout_duration=300  # Timeout after 5 minutes (300 seconds)
+timeout_duration="${BUILDKITE_PLUGIN_DATA_THEOREM_MOBILE_SECURE_POLLING_TIMEOUT:-300}"  # Default: 5 minutes (300 seconds)
 
 for (( retry = 0; retry < maxRetries; retry++ )); do
     # Step 1: get the upload URL
@@ -192,7 +192,7 @@ if $upload_success && [[ "$POLL_SCAN_RESULTS" == "true" ]]; then
         elapsed_time=$((current_time - start_time))
 
         if [ $elapsed_time -gt $timeout_duration ]; then
-            echo "Timeout: Static scan did not complete within 5 minutes."
+            echo "Timeout: Static scan did not complete within ${timeout_duration} seconds."
             exit 0
         fi
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -33,6 +33,13 @@ configuration:
         HIGH: Block on high severity vulnerabilities only
         MEDIUM: Block on medium and high severity vulnerabilities
         LOW: Block on all severity vulnerabilities (low, medium, high)
+    POLLING_TIMEOUT:
+      type: number
+      default: 300
+      description: |
+        Timeout duration in seconds for polling scan results.
+        Default is 300 seconds (5 minutes).
+        Only applies when POLL_SCAN_RESULTS is true or BLOCK_ON_SEVERITY is set.
   required:
     - UPLOAD_API_KEY
     - BINARY_PATH


### PR DESCRIPTION
This pull request introduces a configurable timeout for polling scan results, allowing users to control how long the plugin waits for scans to complete before proceeding. The new `POLLING_TIMEOUT` parameter is documented, added to the plugin configuration, and integrated into the command logic to replace the previously hardcoded 5-minute timeout.

Configuration and documentation updates:

* Added a new `POLLING_TIMEOUT` parameter to the plugin configuration in `plugin.yml`, defaulting to 300 seconds (5 minutes), with a description of its usage.
* Updated the `README.md` to document the `POLLING_TIMEOUT` parameter, including its purpose, default value, and example usage. Also clarified the build blocking step to reflect the configurable timeout. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R142-R150) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L90-R90)

Command logic changes:

* Updated `hooks/command` to use the `POLLING_TIMEOUT` environment variable (with a default of 300 seconds) for scan polling, replacing the previously hardcoded timeout value.
* Improved the timeout error message to display the actual timeout duration in seconds, rather than a fixed 5 minutes.